### PR TITLE
Allow response mode to be configured in constructor

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,6 +48,7 @@ class PortierClient {
     this.store = params.store || new MemoryStore()
     this.broker = params.broker || 'https://broker.portier.io'
     this.redirectUri = params.redirectUri
+    this.responseMode = params.responseMode || 'form_post'
 
     this.leeway = 3 * 60 * 1000  // 3 minutes
     this.clientId = getOrigin(this.redirectUri)
@@ -84,7 +85,7 @@ class PortierClient {
         scope: 'openid email',
         nonce: nonce,
         response_type: 'id_token',
-        response_mode: 'form_post',
+        response_mode: this.responseMode,
         client_id: this.clientId,
         redirect_uri: this.redirectUri
       })


### PR DESCRIPTION
This will allow to set response mode to `fragment`, so the broker can redirect to a url from a Single Page Application for example. When the SPA receives the verification token from the broker, it can send it back to the server for verification and obtain a long lived JWT to stay logged in in a stateless way.