### PR TITLE
Don't directly export the Redis store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export { default as PortierClient } from "./client";
 export { default as AbstractStore } from "./store";
 export { default as MemoryStore } from "./stores/memory";
-export { default as RedisStore } from "./stores/redis";
 export { default as normalize } from "./normalize";


### PR DESCRIPTION
Specifically for TypeScript, because we were accidentally pulling in Redis types this way.