### PR TITLE
Add path to types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "Portier client for Node.js",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/portier/portier-node.git"

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,11 +17,11 @@ const getOrigin = (input: string): string => {
 
   if (protocol === "http:") {
     if (port === "80") {
-      port = undefined;
+      port = null;
     }
   } else if (protocol === "https:") {
     if (port === "443") {
-      port = undefined;
+      port = null;
     }
   } else {
     throw Error(`Unsupported URL scheme: ${protocol || ""}`);

--- a/src/stores/redis.ts
+++ b/src/stores/redis.ts
@@ -22,7 +22,7 @@ export default class RedisStore extends AbstractStore {
     const key = `cache:${cacheId}`;
 
     // Check if the item exists.
-    const item: string = await new Promise((resolve, reject) => {
+    const item: string | null = await new Promise((resolve, reject) => {
       this.client.get(key, (err, data) => {
         err ? reject(err) : resolve(data);
       });


### PR DESCRIPTION
This PR updates `package.json` with the path to the generated TypeScript types, which allows other TypeScript projects to pick up the types.

Additionally, it fixes two small errors that the newer versions of the TypeScript compiler now pick up.